### PR TITLE
Fix CVx validation

### DIFF
--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -43,8 +43,7 @@ export default class Validator {
         if (this.validateNumericOnly(cvv) === true) {
             if (cardType === "AMEX" && (cvv.length === 3 || cvv.length === 4)) {
                 return true;
-            }
-            if (cardType === "CBVISAMASTERCARD" && cvv.length === 3) {
+            } else if (cvv.length === 3) {
                 return true;
             }
         }


### PR DESCRIPTION
Hello,

This fix **cvx validation** that always return an error if the `cardType` isn't:
- `MAESTRO`
- `BCMC`
- `AMEX`
or
- `CBVISAMASTERCARD`