### PR TITLE
add cardType CB_VISA_MASTERCARD into validator

### DIFF
--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -44,7 +44,7 @@ export default class Validator {
             if (cardType === "AMEX" && (cvv.length === 3 || cvv.length === 4)) {
                 return true;
             }
-            if (cardType === "CBVISAMASTERCARD" && cvv.length === 3) {
+            if ( (cardType === "CBVISAMASTERCARD" || cardType === "CB_VISA_MASTERCARD") && cvv.length === 3) {
                 return true;
             }
         }


### PR DESCRIPTION
Adding cardType CB_VISA_MASTERCARD. Can be confusing to use CBVISAMASTERCARD because MangoPay API use snakeCase (CB_VISA_MASTERCARD).